### PR TITLE
Refactor WordPress core structure

### DIFF
--- a/.env
+++ b/.env
@@ -9,10 +9,6 @@ APP_ADMIN_EMAIL=wolat@example.com
 # APP_TITLE="My Cool App"
 # APP_LOCALE=
 
-# Specify directory where to install WordPress core
-# `wordpress` by default
-# APP_CORE_DIR=
-
 # Database connection
 # DB_HOST value will be set to `kawa-db` (same as MySQL container name)
 DB_NAME='wolat'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  ## Changes
+
+  $CHANGES
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feat'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  default: patch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,28 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          release-notes: ${{ github.event.release.body }}
+          latest-version: ${{ github.event.release.name }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: master
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 
 # Generated on a first run password for admin user
 admin-pass.txt
-wordpress
+wordpress/*
+!wordpress/.gitkeep

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package provides simple Docker compose environment for **WordPress local de
 
 It uses built-in PHP web server and MySQL connection with no fancy configs yet still customizable. This is why we're not recommending this package in production - any other web-server provides much more options. However in a development process most of the time all you need is to run simple working server
 
-By default it install WordPress core into `wordpress` directory but you may provide any custom directory plus you may specify if you want to install Bedrock configuration
+WordPress core will be installed within `wordpress` directory
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: Dockerfile
     image: czernika/kawa-8.0
     volumes:
-      - .:/var/www/html
+      - ./wordpress:/var/www/html
       - ./docker/php.ini:/usr/local/etc/php/conf.d/php.ini
     ports:
       - 80:80
@@ -21,12 +21,11 @@ services:
       APP_URL: ${APP_URL:-http://127.0.0.1}
       APP_LOCALE: ${APP_LOCALE:-en_US}
       APP_TITLE: ${APP_TITLE:-WordPress}
-      APP_CORE_DIR: ${APP_CORE_DIR:-wordpress}
       DB_NAME: ${DB_NAME:-wolat}
       DB_USER: ${DB_USER:-wolat}
       DB_PASSWORD: ${DB_PASSWORD:-password}
       DB_PREFIX: ${DB_PREFIX:-wp_}
-      IS_BEDROCK: 1
+      IS_BEDROCK: 0
     depends_on:
       mysql:
         condition: service_healthy

--- a/docker/app-start.sh
+++ b/docker/app-start.sh
@@ -2,7 +2,7 @@
 
 WORKDIR=/var/www/html
 
-APP_CORE_PATH="$WORKDIR/$APP_CORE_DIR"
+APP_CORE_PATH="$WORKDIR"
 APP_WEB_CORE_PATH=$APP_CORE_PATH
 APP_WP_CORE_PATH=$APP_CORE_PATH
 
@@ -17,10 +17,6 @@ function wp_core_is_installed()
 {
     $(wp core is-installed --path=$APP_WP_CORE_PATH)
 }
-
-if [[ ! -d $APP_CORE_PATH ]]; then
-    mkdir $APP_CORE_PATH
-fi
 
 # If this is Bedrock installation
 # Point web server into `web` subdirectory
@@ -47,7 +43,9 @@ if ! wp_core_is_installed; then
 
     # Download WordPress Core depends on environemnt
     if is_bedrock; then
-        composer create-project roots/bedrock $APP_CORE_DIR --prefer-dist
+
+        rm -rf .gitkeep
+        composer create-project roots/bedrock . --prefer-dist
 
         sed -i "s/database_name/$DB_NAME/g" $APP_CORE_PATH/.env
         sed -i "s/database_user/$DB_USER/g" $APP_CORE_PATH/.env


### PR DESCRIPTION
- **Fix**: error when `wp` command throws an error about not WordPress core without `wp-cli.yml` configuration file
- **Refactor**: only content within `wordpress` directory gets into docker volume
- **Refactor**: removed `APP_CORE_DIR` environment variable 